### PR TITLE
feat(import) Add timeout parameter

### DIFF
--- a/pmc-callbacks/import.lua
+++ b/pmc-callbacks/import.lua
@@ -20,7 +20,7 @@ if IsDuplicityVersion() then
 		local p = promise.new()
 
 		SetTimeout(timeout, function()
-			p:resolve({false})
+			p:resolve({nil})
 		end)
 
 		local e = RegisterNetEvent('__pmc_callback:server:'..eventName, function(...)
@@ -50,7 +50,7 @@ if not IsDuplicityVersion() then
 		local ticket = GetGameTimer()
 
 		SetTimeout(timeout, function()
-			p:resolve({false})
+			p:resolve({nil})
 		end)
 
 		local e = RegisterNetEvent(('__pmc_callback:client:%s:%s'):format(eventName, ticket), function(...)

--- a/pmc-callbacks/import.lua
+++ b/pmc-callbacks/import.lua
@@ -20,7 +20,7 @@ if IsDuplicityVersion() then
 		local p = promise.new()
 
 		SetTimeout(timeout, function()
-			p:resolve({nil})
+			p:reject({err="Timeout reached})
 		end)
 
 		local e = RegisterNetEvent('__pmc_callback:server:'..eventName, function(...)
@@ -50,7 +50,7 @@ if not IsDuplicityVersion() then
 		local ticket = GetGameTimer()
 
 		SetTimeout(timeout, function()
-			p:resolve({nil})
+			p:reject({err="Timeout reached"})
 		end)
 
 		local e = RegisterNetEvent(('__pmc_callback:client:%s:%s'):format(eventName, ticket), function(...)

--- a/pmc-callbacks/import.lua
+++ b/pmc-callbacks/import.lua
@@ -11,23 +11,29 @@ if IsDuplicityVersion() then
 		end)
 	end
 
-	_G.TriggerClientCallback = function(src, eventName, ...)
+	_G.TriggerClientCallback = function(src, eventName, timeout, ...)
 		assert(type(src) == 'number', 'Invalid Lua type at argument #1, expected number, got '..type(src))
 		assert(type(eventName) == 'string', 'Invalid Lua type at argument #2, expected string, got '..type(eventName))
+		assert(type(timeout) == 'number', 'Invalid Lua type at argument #3, expected number, got '..type(timeout))
 
+		local result
 		local p = promise.new()
-	
-		RegisterNetEvent('__pmc_callback:server:'..eventName)
-		local e = AddEventHandler('__pmc_callback:server:'..eventName, function(...)
+
+		SetTimeout(timeout, function()
+			p:resolve({false})
+		end)
+
+		local e = RegisterNetEvent('__pmc_callback:server:'..eventName, function(...)
 			local s = source
 			if src == s then
 				p:resolve({...})
 			end
 		end)
-	
+
 		TriggerClientEvent('__pmc_callback:client', src, eventName, ...)
-	
-		local result = Citizen.Await(p)
+
+		result = Citizen.Await(p)
+
 		RemoveEventHandler(e)
 		return table.unpack(result)
 	end
@@ -35,20 +41,26 @@ end
 
 -- CLIENT-SIDE
 if not IsDuplicityVersion() then
-	_G.TriggerServerCallback = function(eventName, ...)
+	_G.TriggerServerCallback = function(eventName, timeout, ...)
 		assert(type(eventName) == 'string', 'Invalid Lua type at argument #1, expected string, got '..type(eventName))
+		assert(type(timeout) == 'number', 'Invalid Lua type at argument #2, expected number, got '..type(timeout))
 
+		local result
 		local p = promise.new()
 		local ticket = GetGameTimer()
-	
-		RegisterNetEvent(('__pmc_callback:client:%s:%s'):format(eventName, ticket))
-		local e = AddEventHandler(('__pmc_callback:client:%s:%s'):format(eventName, ticket), function(...)
+
+		SetTimeout(timeout, function()
+			p:resolve({false})
+		end)
+
+		local e = RegisterNetEvent(('__pmc_callback:client:%s:%s'):format(eventName, ticket), function(...)
 			p:resolve({...})
 		end)
-	
+
 		TriggerServerEvent('__pmc_callback:server', eventName, ticket, ...)
-	
-		local result = Citizen.Await(p)
+
+		result = Citizen.Await(p)
+
 		RemoveEventHandler(e)
 		return table.unpack(result)
 	end


### PR DESCRIPTION
- Add timeout as a required parameter, ensuring that a value is always returned, and we're not indefinitely waiting for a promise to be resolved
- Removed AddEventHandler under RegisterNetEvent as the latter can now take callbacks